### PR TITLE
Make Crossplane CLI version and channel configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,14 @@ on:
   pull_request: {}
   workflow_dispatch:
     inputs:
+      cli_channel:
+        description: The channel of the crossplane CLI to use
+        required: true
+        default: stable
+      cli_version:
+        description: The version of the crossplane CLI to use
+        required: true
+        default: current
       version:
         description: Package version (e.g. v0.1.0)
         required: false
@@ -18,12 +26,8 @@ env:
   GOLANGCI_VERSION: 'v2.2.1'
   DOCKER_BUILDX_VERSION: 'v0.23.0'
 
-  # These environment variables are important to the Crossplane CLI install.sh
-  # script. They determine what version it installs. This function installs the
-  # latest main branch build because we use function-dummy in E2E tests, so we
-  # often need to build it with unreleased features.
-  XP_CHANNEL: master
-  XP_VERSION: current
+  XP_CHANNEL: ${{ inputs.cli_channel }}
+  XP_VERSION: ${{ inputs.cli_version }}
 
   # This CI job will automatically push new builds to xpkg.upbound.io if the
   # XPKG_ACCESS_ID and XPKG_TOKEN secrets are set in the GitHub respository (or


### PR DESCRIPTION
I need to build v0.4.1 with the lastest crank build from c/c main, merged about an hour ago. This repo uses master/current but I think caching is getting in the way - it's still using build 200 when current is really 232: https://github.com/crossplane-contrib/function-dummy/actions/runs/16301672541/job/46037560763?pr=45

So I'd like to explicitly tell it what version to use instead.